### PR TITLE
Fix Maven Plugin warning of not using provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,7 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
       <version>4.0.2</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -366,12 +366,18 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.9.3</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>3.9.0</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>4.0.0</version>
     </dependency>
     <dependency>
       <groupId>net.logicsquad</groupId>
@@ -400,6 +406,11 @@
       <artifactId>itf-jupiter-extension</artifactId>
       <version>0.12.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+      <version>4.0.2</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
plexus-utils is required for the org.codehaus.plexus.util.DirectoryScanner

plexus-xml is required for the MavenJupiterExtension, if not provided it causes a java.lang.NoClassDefFoundError: org/codehaus/plexus/util/xml/pull/XmlPullParserException

Fixes #2 

